### PR TITLE
editTaskFeature

### DIFF
--- a/src/main/kotlin/com/github/ursteiner/todofx/controller/ToDoFxController.kt
+++ b/src/main/kotlin/com/github/ursteiner/todofx/controller/ToDoFxController.kt
@@ -7,10 +7,7 @@ import com.github.ursteiner.todofx.view.FxMessageDialog
 import javafx.collections.FXCollections
 import javafx.fxml.FXML
 import javafx.fxml.Initializable
-import javafx.scene.control.CheckBox
-import javafx.scene.control.Label
-import javafx.scene.control.TableView
-import javafx.scene.control.TextArea
+import javafx.scene.control.*
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -22,13 +19,16 @@ class ToDoFxController : Initializable {
     private lateinit var taskNameInput: TextArea
 
     @FXML
-    private lateinit var taskPreview: Label
+    private lateinit var taskUpdateArea: TextArea
 
     @FXML
     private lateinit var tableView: TableView<Task>
 
     @FXML
     private lateinit var hideDoneTasksCheckBox: CheckBox
+
+    @FXML
+    private lateinit var updateTaskButton: Button
 
     private val dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
     private val databaseService : DatabaseService = DatabaseServiceImpl("~/tasks")
@@ -71,7 +71,7 @@ class ToDoFxController : Initializable {
         databaseService.deleteTask(selectedTask.getIdProperty())
         tasks.remove(selectedTask)
         onHideDoneTaskCheckBoxChanged()
-        taskPreview.text = ""
+        taskUpdateArea.text = ""
     }
 
     @FXML
@@ -84,9 +84,26 @@ class ToDoFxController : Initializable {
 
         selectedTask.setIsDoneProperty(!selectedTask.getIsDoneProperty())
         setTaskDoneIcon(selectedTask)
-        databaseService.updateTask(selectedTask)
+        databaseService.updateTask(selectedTask, selectedTask.getNameProperty())
 
         onHideDoneTaskCheckBoxChanged()
+    }
+    @FXML
+    private fun onUpdateTaskButtonClick(){
+        val selectedTask = tableView.selectionModel.selectedItem
+        if(selectedTask == null) {
+            showDialogMessageFirstSelectATask()
+            return
+        }
+        System.out.println(selectedTask.getIdProperty());
+        System.out.println(taskUpdateArea.text);
+        databaseService.updateTask(selectedTask, taskUpdateArea.text);
+        refreshTableView();
+    }
+    @FXML
+    private fun refreshTableView() {
+        val updatedTaskList = databaseService.getTasks();
+        tableView.items.setAll(updatedTaskList);
     }
 
     private fun setTaskDoneIcon(task: Task){
@@ -101,7 +118,11 @@ class ToDoFxController : Initializable {
     private fun onTaskSelected(){
         val selectedTask = tableView.selectionModel.selectedItem
         if(selectedTask != null) {
-            taskPreview.text = selectedTask.getNameProperty()
+            taskUpdateArea.text = selectedTask.getNameProperty()
+            taskUpdateArea.isVisible = true;
+            taskUpdateArea.isManaged = true
+            updateTaskButton.isVisible = true;
+            updateTaskButton.isManaged = true
         }
     }
 

--- a/src/main/kotlin/com/github/ursteiner/todofx/service/DatabaseService.kt
+++ b/src/main/kotlin/com/github/ursteiner/todofx/service/DatabaseService.kt
@@ -7,5 +7,5 @@ interface DatabaseService {
     fun addTask(newTask: Task)
     fun getTasks() : MutableList<Task>
     fun deleteTask(taskId: Int) : Int
-    fun updateTask(task: Task) : Int
+    fun updateTask(task: Task, newName:String) : Int
 }

--- a/src/main/kotlin/com/github/ursteiner/todofx/service/DatabaseServiceImpl.kt
+++ b/src/main/kotlin/com/github/ursteiner/todofx/service/DatabaseServiceImpl.kt
@@ -67,14 +67,14 @@ class DatabaseServiceImpl : DatabaseService {
         return deletedTasks
     }
 
-    override fun updateTask(task: Task) : Int {
+    override fun updateTask(task: Task, newName:String) : Int {
         var updatedTasks = 0
 
         transaction {
             addLogger(StdOutSqlLogger)
             updatedTasks = Tasks.update({ Tasks.id eq task.getIdProperty() }) {
                 it[isDone] = task.getIsDoneProperty()
-                it[name] = task.getNameProperty()
+                it[name] = newName;
             }
         }
         return updatedTasks

--- a/src/main/resources/com/github/ursteiner/todofx/toDoFx-view.fxml
+++ b/src/main/resources/com/github/ursteiner/todofx/toDoFx-view.fxml
@@ -21,7 +21,8 @@
             <Label>Description</Label>
             <TextArea prefColumnCount="3" wrapText="true" fx:id="taskNameInput"/>
             <Button text="Add task" onAction="#onAddTaskButtonClick"/>
-            <Label fx:id="taskPreview" wrapText="true"/>
+            <TextArea fx:id="taskUpdateArea" maxHeight="100" wrapText="true" visible="false" managed="false"/>
+            <Button text="Update task" fx:id="updateTaskButton" onAction="#onUpdateTaskButtonClick" visible="false" managed="false"/>
         </VBox>
         <VBox minWidth="10"/>
         <VBox>


### PR DESCRIPTION
Closes #1 

I changed the label to a textArea also added the Update Task button below it. 

Modified the Database service update method to include the name parameter, so you can call the same method when you update the state of done of the task or just update the name of it. 

When you click the button update, it updates the task on the db and also refresh the products on the tableView to see the new name of your task
<img width="700" alt="Screenshot 2025-04-21 at 2 55 30 p m" src="https://github.com/user-attachments/assets/bcdfd0b9-dfb5-4cca-b5c9-2fde4c4d6e1d" />

<img width="701" alt="Screenshot 2025-04-21 at 2 55 39 p m" src="https://github.com/user-attachments/assets/0b5eab18-b40a-4bba-96fc-23031439ce05" />

